### PR TITLE
Changed request serialized data

### DIFF
--- a/aiorest_ws/routers.py
+++ b/aiorest_ws/routers.py
@@ -126,7 +126,6 @@ class SimpleRouter(AbstractRouter):
                 serializer = handler.get_serializer(format, *args, **kwargs)
 
                 response.content = handler.dispatch(request, *args, **kwargs)
-                response.append_request(request)
             else:
                 raise NotSpecifiedHandler()
         except BaseAPIException as exc:
@@ -134,6 +133,7 @@ class SimpleRouter(AbstractRouter):
             response.wrap_exception(exc)
             serializer = JSONSerializer()
 
+        response.append_request(request)
         return serializer.serialize(response.content)
 
     def _register_url(self, route):

--- a/aiorest_ws/wrappers.py
+++ b/aiorest_ws/wrappers.py
@@ -14,6 +14,7 @@ class Request(object):
         self._method = kwargs.pop('method', None)
         self._url = kwargs.pop('url', None)
         self._args = kwargs.pop('args', {})
+        self._event_name = kwargs.pop('event_name', None)
 
         for key in kwargs.keys():
             add_property(self, key, kwargs[key])
@@ -33,9 +34,14 @@ class Request(object):
         """Get dictionary of arguments, defined by the user."""
         return self._args
 
+    @property
+    def event_name(self):
+        """Get event name, which used by the client for processing response."""
+        return self._event_name
+
     def to_representation(self):
-        """Serialize request object."""
-        return {'method': self.method, 'url': self.url}
+        """Serialize request object to dictionary object."""
+        return {'event_name': self.event_name}
 
     def get_argument(self, name):
         """Extracting argument from the request.
@@ -67,4 +73,4 @@ class Response(object):
 
     def append_request(self, request):
         """Add to the response object serialized request."""
-        self._content.update({'request': request.to_representation()})
+        self._content.update(request.to_representation())

--- a/docs/source/request.rst
+++ b/docs/source/request.rst
@@ -28,14 +28,14 @@ scheme:
 
 4) Get response data from :class:`Response` instance and encode message.
 
-5) Send result data (in the same form, which has taken at the 1st step) to the client.
+5) Send result data (in the same form, which had taken at the 1st step) to the client.
 
 
 Also what necessary to know, when you're working with this protocol:
 
 1) Protocols can retrieve the message, why a connection was terminated.
 
-2) Create multiple connections to a server.
+2) You can create multiple connections to a server.
 
 RequestHandler factory
 ----------------------

--- a/docs/source/wrappers.rst
+++ b/docs/source/wrappers.rst
@@ -31,12 +31,20 @@ Properties:
     and a part of him, parameters, converted later to the dictionary
     ``{'name': admin, 'password': admin}``.
 
+- event_name
+
+    Returns event name, which defined by the client in the request.
+
+    This string value will have appended to response and used by aiorest-ws clients
+    dispatchers, when necessary to find the most suitable registered function, which
+    intended for processing response.
+
 Available methods:
 
 - to_representation
 
     Returns part of request as a dictionary object. It used for serializing and
-    appending ``method``, ``url`` part to the response object.
+    appending ``event_name`` to the response object.
 
 - get_argument
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -60,33 +60,23 @@ class RequestTestCase(unittest.TestCase):
     def test_to_representation(self):
         data = {}
         request = Request(**data)
-        self.assertEqual(
-            request.to_representation(),
-            {'method': None, 'url': None}
-        )
+        self.assertEqual(request.to_representation(), {'event_name': None})
 
     def test_to_representation_2(self):
         data = {'url': '/api'}
         request = Request(**data)
-        self.assertEqual(
-            request.to_representation(),
-            {'method': None, 'url': '/api'}
-        )
+        self.assertEqual(request.to_representation(), {'event_name': None})
 
     def test_to_representation_3(self):
         data = {'method': 'GET'}
         request = Request(**data)
-        self.assertEqual(
-            request.to_representation(),
-            {'method': 'GET', 'url': None}
-        )
+        self.assertEqual(request.to_representation(), {'event_name': None})
 
     def test_to_representation_4(self):
-        data = {'url': '/api', 'method': 'GET'}
+        data = {'url': '/api', 'method': 'GET', 'event_name': 'test-event'}
         request = Request(**data)
         self.assertEqual(
-            request.to_representation(),
-            {'method': 'GET', 'url': '/api', }
+            request.to_representation(), {'event_name': data['event_name']}
         )
 
     def test_get_argument(self):
@@ -147,10 +137,15 @@ class ResponseTestCase(unittest.TestCase):
         self.assertEqual(response._content['detail'], exception.detail)
 
     def test_append_request(self):
+        data = {'url': '/api', 'method': 'GET', 'event_name': 'test-event'}
+        request = Request(**data)
+        response = Response()
+        response.append_request(request)
+        self.assertEqual(response.content['event_name'], request.event_name)
+
+    def test_append_request_with_undefined_event_name(self):
         data = {'url': '/api', 'method': 'GET'}
         request = Request(**data)
         response = Response()
         response.append_request(request)
-        self.assertEqual(
-            response.content['request'], request.to_representation()
-        )
+        self.assertEqual(response.content['event_name'], request.event_name)


### PR DESCRIPTION
At this PR I've changed returned data from the Request object. This changes are important because:
1) It minimize transmitted traffic through WebSockets
2) Simplify further implementation of Python/JavaScript clients for aiorest-ws library