### PR TITLE
Inference url for HyperlinkedModelSerializer

### DIFF
--- a/aiorest_ws/db/orm/sqlalchemy/field_mapping.py
+++ b/aiorest_ws/db/orm/sqlalchemy/field_mapping.py
@@ -13,7 +13,7 @@ from aiorest_ws.utils.text import capfirst
 
 __all__ = (
     'STRING_TYPES', 'get_detail_view_name', 'get_field_kwargs',
-    'get_relation_kwargs', 'get_nested_relation_kwargs'
+    'get_relation_kwargs', 'get_nested_relation_kwargs', 'get_url_kwargs'
 )
 
 STRING_TYPES = (
@@ -134,3 +134,9 @@ def get_nested_relation_kwargs(relation_info):
     if relation_info.to_many:
         kwargs['many'] = True
     return kwargs
+
+
+def get_url_kwargs(model_field):
+    return {
+        'view_name': get_detail_view_name(model_field)
+    }

--- a/aiorest_ws/db/orm/sqlalchemy/serializers.py
+++ b/aiorest_ws/db/orm/sqlalchemy/serializers.py
@@ -14,7 +14,7 @@ from aiorest_ws.db.orm.serializers import \
     raise_errors_on_nested_writes
 from aiorest_ws.db.orm.sqlalchemy import model_meta
 from aiorest_ws.db.orm.sqlalchemy.field_mapping import get_field_kwargs, \
-    get_relation_kwargs, get_nested_relation_kwargs
+    get_relation_kwargs, get_nested_relation_kwargs, get_url_kwargs
 from aiorest_ws.db.orm.exceptions import ValidationError
 from aiorest_ws.utils.field_mapping import ClassLookupDict
 
@@ -375,6 +375,9 @@ class ModelSerializer(BaseModelSerializer):
         elif hasattr(model_class, field_name):
             return self.build_property_field(field_name, model_class)
 
+        elif field_name == self.url_field_name:
+            return self.build_url_field(field_name, model_class)
+
         return self.build_unknown_field(field_name, model_class)
 
     def build_standard_field(self, *args, **kwargs):
@@ -476,6 +479,15 @@ class ModelSerializer(BaseModelSerializer):
         """
         field_class = ReadOnlyField
         field_kwargs = {}
+
+        return field_class, field_kwargs
+
+    def build_url_field(self, field_name, model_class):
+        """
+        Create a field representing the object's own URL.
+        """
+        field_class = self.serializer_url_field
+        field_kwargs = get_url_kwargs(model_class)
 
         return field_class, field_kwargs
 

--- a/examples/sqlalchemy_orm/server/app/db.py
+++ b/examples/sqlalchemy_orm/server/app/db.py
@@ -11,7 +11,7 @@ class User(Base):
     id = Column(Integer, primary_key=True)
     name = Column(String(50), unique=True)
     fullname = Column(String(50), default='Unknown')
-    password = Column(String(12))
+    password = Column(String(512))
     addresses = relationship("Address", back_populates="user")
 
     @validates('name')

--- a/tests/db/orm/sqlalchemy/test_field_mapping.py
+++ b/tests/db/orm/sqlalchemy/test_field_mapping.py
@@ -2,7 +2,8 @@
 import unittest
 
 from aiorest_ws.db.orm.sqlalchemy.field_mapping import get_detail_view_name, \
-    get_field_kwargs, get_relation_kwargs, get_nested_relation_kwargs
+    get_field_kwargs, get_relation_kwargs, get_nested_relation_kwargs, \
+    get_url_kwargs
 from aiorest_ws.utils.structures import RelationInfo
 
 from tests.fixtures.sqlalchemy import ENGINE, SESSION
@@ -276,4 +277,17 @@ class TestGetNestedRelationKwargs(unittest.TestCase):
         self.assertEqual(
             get_nested_relation_kwargs(relation_info),
             {'read_only': True, 'many': True}
+        )
+
+
+class TestGetUrlKwargsName(unittest.TestCase):
+
+    def test_get_url_kwargs_name(self):
+
+        class TestUserModel(object):
+            __tablename__ = 'user'
+
+        self.assertEqual(
+            get_url_kwargs(TestUserModel),
+            {'view_name': 'user-detail'}
         )

--- a/tests/db/orm/sqlalchemy/test_serializers.py
+++ b/tests/db/orm/sqlalchemy/test_serializers.py
@@ -5,7 +5,8 @@ from aiorest_ws.exceptions import ImproperlyConfigured
 from aiorest_ws.db.orm.validators import BaseValidator
 from aiorest_ws.db.orm.abstract import empty
 from aiorest_ws.db.orm.exceptions import ValidationError
-from aiorest_ws.db.orm.sqlalchemy.relations import ManyRelatedField
+from aiorest_ws.db.orm.sqlalchemy.relations import ManyRelatedField, \
+    HyperlinkedIdentityField
 from aiorest_ws.db.orm.serializers import Serializer
 from aiorest_ws.db.orm.sqlalchemy.serializers import ListSerializer, \
     ModelSerializer, HyperlinkedModelSerializer, get_validation_error_detail
@@ -596,6 +597,28 @@ class TestModelSerializer(unittest.TestCase):
         self.assertIsInstance(
             instance.fields['user_info'],
             fields.ReadOnlyField
+        )
+
+    def test_build_url_field(self):
+
+        class UserSerializer(HyperlinkedModelSerializer):
+            class Meta:
+                model = self.TestModelSerializerUserModel
+                fields = ('url', 'name', 'addresses')
+                extra_kwargs = {'url': {'view_name': 'users'}}
+
+        data = {
+            'name': 'admin',
+            'addresses': [],
+            'gender': 'male'
+        }
+        instance = UserSerializer(data=data)
+
+        url_serializer = instance.fields['url']
+        self.assertIsInstance(url_serializer, HyperlinkedIdentityField)
+        self.assertEqual(
+            url_serializer.__class__.__name__,
+            "HyperlinkedIdentityField"
         )
 
     def test_build_unknown_field(self):


### PR DESCRIPTION
This feature let to use built URL to an object based on the SQLAlchemy ORM data.

For example you can write a serializer for your model like this:
```python
# db.py 
from sqlalchemy.ext.declarative import declarative_base
from sqlalchemy import Column, Integer, String, ForeignKey
from sqlalchemy.orm import relationship, validates

Base = declarative_base()


class User(Base):
    __tablename__ = 'user'
    id = Column(Integer, primary_key=True)
    name = Column(String(50), unique=True)
    fullname = Column(String(50), default='Unknown')
    password = Column(String(512))


# serializers.py
from db import User
from aiorest_ws.db.orm.sqlalchemy import serializers

class UserSerializer(serializers.HyperlinkedModelSerializer):

    class Meta:
        model = User
```

After that if we will try to get an instance of User model, then our `UserSerializer` returns with serialized object also append the `url` field to response. This field is storing URL to an existing object. To get a link hyperlink to the existing object serializer try to inference `view_name` based on the metadata from the table and try to get an access to this object via registered view with the `user-detail` name. Of course, your views can have another name, just pass extra argument to the `Meta` class, like:
``` python
class UserSerializer(serializers.HyperlinkedModelSerializer):

    class Meta:
        model = User
        extra_kwargs = {'url': {'view_name': 'another-user-detail-view'}}
```